### PR TITLE
Updaing npm start script to use nr1 #noissue

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "email": "opensource@newrelic.com"
   },
   "scripts": {
-    "start": "nr1-dev nerdpack:serve",
+    "start": "nr1 nerdpack:serve",
     "test": "exit 0",
     "eslint-check": "eslint nerdlets/",
     "eslint-fix": "eslint nerdlets/ --fix"


### PR DESCRIPTION
The current npm start script uses nr1-dev. Making this change to default to nr1.