### PR TITLE
Fix: quick start dropdown now behaves properly in Safari (#26)

### DIFF
--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -424,16 +424,16 @@ export default class StatusPagesDashboard extends React.Component {
             label="Quick setup"
             className="status-page-setting"
           >
-            <DropdownItem onClick={() => this.handleQuickSetupSelect(event)}>
+            <DropdownItem onClick={e => this.handleQuickSetupSelect(e)}>
               Google Cloud
             </DropdownItem>
-            <DropdownItem onClick={() => this.handleQuickSetupSelect(event)}>
+            <DropdownItem onClick={e => this.handleQuickSetupSelect(e)}>
               GitHub
             </DropdownItem>
-            <DropdownItem onClick={() => this.handleQuickSetupSelect(event)}>
+            <DropdownItem onClick={e => this.handleQuickSetupSelect(e)}>
               Jira
             </DropdownItem>
-            <DropdownItem onClick={() => this.handleQuickSetupSelect(event)}>
+            <DropdownItem onClick={e => this.handleQuickSetupSelect(e)}>
               New Relic
             </DropdownItem>
           </Dropdown>


### PR DESCRIPTION
When using Safari, in the "Add a new service" form, when a user clicks on a quick start option, the form would not respond. The issue is that the event was never passed through from the onClick functions that handle "quick start" clicks. Chrome made up for it and knew what was meant, Safari didn't. Now resolved.

---
When merged, will resolved issue #26.