### PR TITLE
fix: Make popover menu disappear onMouseLeave

### DIFF
--- a/components/status-page.js
+++ b/components/status-page.js
@@ -41,6 +41,8 @@ export default class StatusPage extends React.Component {
       this.props.hostname.provider
     );
     this.FormatService = new FormatService(this.props.hostname.provider);
+    this.popupHoverTimer = null;
+
     this.state = {
       statusPageIoSummaryData: undefined,
       inputValue: '',
@@ -58,6 +60,11 @@ export default class StatusPage extends React.Component {
     );
     this.handleSettingsPopover = this.handleSettingsPopover.bind(this);
     this.handleEditButtonClick = this.handleEditButtonClick.bind(this);
+    this.handleSettingsButtonMouseLeave = this.handleSettingsButtonMouseLeave.bind(
+      this
+    );
+    this.handlePopupMouseEnter = this.handlePopupMouseEnter.bind(this);
+    this.handlePopupMouseLeave = this.handlePopupMouseLeave.bind(this);
 
     this.serviceTilePrimaryContent = React.createRef();
     this.serviceTileSettingsContent = React.createRef();
@@ -279,6 +286,24 @@ export default class StatusPage extends React.Component {
     this.handleTileSettingsAnimation();
   }
 
+  handleSettingsButtonMouseLeave() {
+    this.popupHoverTimer = setTimeout(() => {
+      this.setState({ settingsPopoverActive: false });
+    }, 150);
+  }
+
+  handlePopupMouseEnter() {
+    if (this.popupHoverTimer) {
+      clearTimeout(this.popupHoverTimer);
+    }
+  }
+
+  handlePopupMouseLeave() {
+    this.popupHoverTimer = setTimeout(() => {
+      this.setState({ settingsPopoverActive: false });
+    }, 150);
+  }
+
   renderSettingsButton() {
     const hostname = this.props.hostname;
     return (
@@ -288,6 +313,7 @@ export default class StatusPage extends React.Component {
             ? 'settings-popover-active'
             : 'settings-popover-inactive'
         }`}
+        onMouseLeave={this.handleSettingsButtonMouseLeave}
       >
         <Button
           sizeType={Button.SIZE_TYPE.SMALL}
@@ -296,7 +322,11 @@ export default class StatusPage extends React.Component {
           iconType={Button.ICON_TYPE.INTERFACE__OPERATIONS__MORE}
           onClick={this.handleSettingsPopover}
         />
-        <ul className="service-settings-dropdown">
+        <ul
+          className="service-settings-dropdown"
+          onMouseEnter={this.handlePopupMouseEnter}
+          onMouseLeave={this.handlePopupMouseLeave}
+        >
           <li className="service-settings-dropdown-item">
             <Icon type={Icon.TYPE.INTERFACE__INFO__INFO} />
             View details

--- a/components/status-page.js
+++ b/components/status-page.js
@@ -483,8 +483,6 @@ export default class StatusPage extends React.Component {
       hostnameGeneric,
     } = this.props;
 
-    console.log(hostnameGeneric);
-
     const { settingsViewActive } = this.state;
 
     return (

--- a/nerdlets/status-page-dashboard/styles.scss
+++ b/nerdlets/status-page-dashboard/styles.scss
@@ -913,6 +913,7 @@ button[class*='Dropdown-trigger'],
 
   &:hover {
     cursor: pointer;
+    background-color: #fafbfb;
   }
 
   .ic-Icon {


### PR DESCRIPTION
There is a menu button on status page card and when you click that button a menu popups up, but it would only ever disappear if you click the menu button again. This PR adjusts the behavior so that the menu disappears when you hover off of it (with a short delay). Here's the new behavior in action:

![freedom 2](https://user-images.githubusercontent.com/812989/77642310-d3769280-6f33-11ea-8a50-73c874892779.gif)


This PR, when merged, will close #42.