### PR TITLE
fix: refreshing timeline fixed

### DIFF
--- a/components/status-page.js
+++ b/components/status-page.js
@@ -215,9 +215,15 @@ export default class StatusPage extends React.PureComponent {
     }
   };
 
-  handleTileClick(statusPageIoSummaryData, refreshRate, hostname, provider, i) {
+  handleTileClick(
+    statusPageIoSummaryData,
+    refreshRate,
+    hostname,
+    provider,
+    selectedIndex
+  ) {
     if (!event.target.closest('.destructive')) {
-      if (i !== undefined) {
+      if (selectedIndex !== undefined) {
         navigation.openStackedNerdlet({
           id: 'service-details',
           urlState: {
@@ -225,7 +231,7 @@ export default class StatusPage extends React.PureComponent {
             refreshRate: refreshRate,
             hostname: hostname,
             provider: provider,
-            timelineItemIndex: i
+            timelineItemIndex: selectedIndex
           }
         });
 

--- a/components/status-page.js
+++ b/components/status-page.js
@@ -228,6 +228,7 @@ export default class StatusPage extends React.PureComponent {
             timelineItemIndex: i
           }
         });
+
         event.stopPropagation();
       } else {
         navigation.openStackedNerdlet({

--- a/nerdlets/service-details/index.js
+++ b/nerdlets/service-details/index.js
@@ -9,7 +9,12 @@ export default class ServiceDetailsWrapper extends React.PureComponent {
         <NerdletStateContext.Consumer>
           {nerdletUrlState => {
             const serviceName = nerdletUrlState.statusPageIoSummaryData.name;
-            const { provider, hostname, timelineItemIndex } = nerdletUrlState;
+            const {
+              provider,
+              hostname,
+              timelineItemIndex,
+              refreshRate
+            } = nerdletUrlState;
 
             return (
               <>
@@ -19,6 +24,7 @@ export default class ServiceDetailsWrapper extends React.PureComponent {
                 <ServiceDetails
                   hostname={hostname}
                   provider={provider}
+                  refreshRate={refreshRate}
                   timelineItemIndex={timelineItemIndex}
                 />
               </>

--- a/nerdlets/service-details/service-details.js
+++ b/nerdlets/service-details/service-details.js
@@ -26,8 +26,6 @@ export default class ServiceDetails extends React.PureComponent {
       this.props.refreshRate,
       this.props.provider
     );
-
-    this.handleTimelineItemClick = this.handleTimelineItemClick.bind(this);
   }
 
   componentDidMount() {
@@ -41,6 +39,26 @@ export default class ServiceDetails extends React.PureComponent {
     if (timelineItemIndex !== undefined && expandedTimelineItem === null) {
       this.setState({ expandedTimelineItem: timelineItemIndex });
     }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (prevProps.hostname !== this.props.hostname) {
+      this.statusPageNetwork.clear();
+
+      this.statusPageNetwork = new Network(
+        this.props.hostname,
+        this.props.refreshRate,
+        this.props.provider
+      );
+
+      this.statusPageNetwork.pollCurrentIncidents(
+        this.setIncidentData.bind(this)
+      );
+    }
+  }
+
+  componentWillUnmount() {
+    this.statusPageNetwork.clear();
   }
 
   setIncidentData(data) {
@@ -107,7 +125,7 @@ export default class ServiceDetails extends React.PureComponent {
     return incident_updates;
   }
 
-  handleTimelineItemClick(e) {
+  handleTimelineItemClick = e => {
     const timelineItemId = e.currentTarget.getAttribute(
       'data-timeline-item-id'
     );
@@ -121,7 +139,7 @@ export default class ServiceDetails extends React.PureComponent {
         expandedTimelineItem: timelineItemId
       });
     }
-  }
+  };
 
   render() {
     const { currentIncidents, expandedTimelineItem } = this.state;

--- a/utilities/network.js
+++ b/utilities/network.js
@@ -11,10 +11,6 @@ export default class Network {
   }
 
   clear = () => {
-    console.log(
-      'Network -> clearTimeout -> this.setTimeoutId',
-      this.setTimeoutId
-    );
     clearTimeout(this.setTimeoutId);
   };
 
@@ -27,8 +23,6 @@ export default class Network {
   _pollData(url, callbackSetterFunction, callbackBeforePolling) {
     this.setTimeoutId = setTimeout(async () => {
       callbackBeforePolling && callbackBeforePolling();
-
-      console.log('polling');
 
       try {
         this._fetchAndPopulateData(url, callbackSetterFunction);

--- a/utilities/network.js
+++ b/utilities/network.js
@@ -7,7 +7,16 @@ export default class Network {
     this.statusPageUrl = statusPageUrl;
     this.refreshRateInSeconds = refreshRateInSeconds;
     this.provider = provider;
+    this.setTimeoutId = undefined;
   }
+
+  clear = () => {
+    console.log(
+      'Network -> clearTimeout -> this.setTimeoutId',
+      this.setTimeoutId
+    );
+    clearTimeout(this.setTimeoutId);
+  };
 
   async _fetchAndPopulateData(url, callbackSetterFunction) {
     const networkResponse = await axios.get(url);
@@ -16,8 +25,10 @@ export default class Network {
   }
 
   _pollData(url, callbackSetterFunction, callbackBeforePolling) {
-    setTimeout(async () => {
+    this.setTimeoutId = setTimeout(async () => {
       callbackBeforePolling && callbackBeforePolling();
+
+      console.log('polling');
 
       try {
         this._fetchAndPopulateData(url, callbackSetterFunction);


### PR DESCRIPTION
Closes #68 

For current state when we cannot determine if StackedNerdlet is closed or not, it's not possible to stop polling data, but refreshing timeline itself is fixed. Also I fixed here data polling, because there was a lot of requests made because of no refreshRate paremeter passed to component.