### PR TITLE
Data polling optimisations and NRQL query as a status page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,22 @@ Example hostnames:
 
 - [https://ezidebit.status.io/pages/history/598a973f96a8201305000142](https://ezidebit.status.io/pages/history/598a973f96a8201305000142)
 - [https://status.docker.com/pages/history/533c6539221ae15e3f000031](https://status.docker.com/pages/history/533c6539221ae15e3f000031)
-=======
+
+### NRQL query
+
+NRQL query requires three fields/aliases to be returned: *EventTimeStamp, EventStatus, EventName*.
+
+Example NRQL query:
+
+```sql
+FROM AlertViolationsSample SELECT timestamp as EventTimeStamp, priority as EventStatus, condition_name as EventName, entity.name LIMIT 50
+```
+
+or
+
+```sql
+SELECT timestamp as EventTimeStamp, priority as EventStatus, condition_name as EventName, entity.name FROM AlertViolationsSample LIMIT 50
+```
 
 ## Open Source License
 

--- a/components/current-incidents.js
+++ b/components/current-incidents.js
@@ -1,71 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Network from '../utilities/network';
 import dayjs from 'dayjs';
 
-import { navigation, Icon, Button } from 'nr1';
-import FormatService from '../utilities/format-service';
-import NRQLHelper from '../utilities/nrql-helper';
-// import { hostname } from 'os';
-
-const NRQL_PROVIDER_NAME = 'nrql';
+import { Icon, Button } from 'nr1';
 
 export default class CurrentIncidents extends React.PureComponent {
   static propTypes = {
     hostname: PropTypes.string,
-    provider: PropTypes.string.isRequired,
-    refreshRate: PropTypes.number,
     handleTileClick: PropTypes.func,
-    accountId: PropTypes.string,
-    nrqlQuery: PropTypes.string
+    currentIncidents: PropTypes.array
   };
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      currentIncidents: undefined,
-      isPolling: false
-    };
-
-    if (this.props.provider !== NRQL_PROVIDER_NAME) {
-      this.statusPageNetwork = new Network(
-        this.props.hostname,
-        this.props.refreshRate,
-        this.props.provider
-      );
-    } else {
-      this.statusPageNetwork = new NRQLHelper(
-        this.props.nrqlQuery,
-        this.props.refreshRate,
-        this.props.accountId
-      );
-    }
-    this.FormatService = new FormatService(this.props.provider);
-
-    this.seeMore = this.seeMore.bind(this);
-  }
-
-  componentDidMount() {
-    this.statusPageNetwork.pollCurrentIncidents(
-      this.setIncidentData.bind(this),
-      () => {
-        const { isPolling } = this.state;
-        this.setState({ isPolling: !isPolling });
-      }
-    );
-  }
-
-  seeMore() {
-    const nerdletWithState = {
-      id: 'incident-details',
-      urlState: {
-        hostname: this.props.hostname,
-        provider: this.props.provider,
-        nrqlQuery: this.props.nrqlQuery
-      }
-    };
-    navigation.openStackedNerdlet(nerdletWithState);
-  }
 
   setTimelineSymbol(incidentImpact) {
     switch (incidentImpact) {
@@ -110,17 +54,8 @@ export default class CurrentIncidents extends React.PureComponent {
     }
   }
 
-  setIncidentData(data) {
-    if (typeof data === 'string') return;
-    this.setState({
-      currentIncidents: this.FormatService.uniformIncidentData(data),
-      isPolling: false
-    });
-  }
-
   render() {
-    const { handleTileClick, hostname } = this.props;
-    const { currentIncidents } = this.state;
+    const { handleTileClick, hostname, currentIncidents } = this.props;
 
     if (!currentIncidents || currentIncidents.length === 0) {
       return (
@@ -138,14 +73,13 @@ export default class CurrentIncidents extends React.PureComponent {
         </div>
       );
     }
-    // console.table(currentIncidents);
-    // this.statusPageNetwork.refreshRateInSeconds = this.props.refreshRate;
-    const first3Incicdents = currentIncidents.slice(0, 3);
-    const first3TimelineItems = first3Incicdents.map((incident, i) => {
+
+    const first3Incidents = currentIncidents.slice(0, 3);
+    const first3TimelineItems = first3Incidents.map((incident, i) => {
       return (
         <div
           className={`timeline-item impact-${incident.impact}`}
-          key={incident.created_at}
+          key={`${incident.created_at}-${i}`}
           onClick={e => {
             handleTileClick(i);
             e.stopPropagation();

--- a/components/current-incidents.js
+++ b/components/current-incidents.js
@@ -5,14 +5,19 @@ import dayjs from 'dayjs';
 
 import { navigation, Icon, Button } from 'nr1';
 import FormatService from '../utilities/format-service';
+import NRQLHelper from '../utilities/nrql-helper';
 // import { hostname } from 'os';
+
+const NRQL_PROVIDER_NAME = 'nrql';
 
 export default class CurrentIncidents extends React.PureComponent {
   static propTypes = {
-    hostname: PropTypes.string.isRequired,
+    hostname: PropTypes.string,
     provider: PropTypes.string.isRequired,
     refreshRate: PropTypes.number,
-    handleTileClick: PropTypes.func
+    handleTileClick: PropTypes.func,
+    accountId: PropTypes.string,
+    nrqlQuery: PropTypes.string
   };
 
   constructor(props) {
@@ -21,12 +26,22 @@ export default class CurrentIncidents extends React.PureComponent {
       currentIncidents: undefined,
       isPolling: false
     };
+
+    if (this.props.provider !== NRQL_PROVIDER_NAME) {
+      this.statusPageNetwork = new Network(
+        this.props.hostname,
+        this.props.refreshRate,
+        this.props.provider
+      );
+    } else {
+      this.statusPageNetwork = new NRQLHelper(
+        this.props.nrqlQuery,
+        this.props.refreshRate,
+        this.props.accountId
+      );
+    }
     this.FormatService = new FormatService(this.props.provider);
-    this.statusPageNetwork = new Network(
-      this.props.hostname,
-      this.props.refreshRate,
-      this.props.provider
-    );
+
     this.seeMore = this.seeMore.bind(this);
   }
 
@@ -45,7 +60,8 @@ export default class CurrentIncidents extends React.PureComponent {
       id: 'incident-details',
       urlState: {
         hostname: this.props.hostname,
-        provider: this.props.provider
+        provider: this.props.provider,
+        nrqlQuery: this.props.nrqlQuery
       }
     };
     navigation.openStackedNerdlet(nerdletWithState);
@@ -122,8 +138,8 @@ export default class CurrentIncidents extends React.PureComponent {
         </div>
       );
     }
-
-    this.statusPageNetwork.refreshRateInSeconds = this.props.refreshRate;
+    // console.table(currentIncidents);
+    // this.statusPageNetwork.refreshRateInSeconds = this.props.refreshRate;
     const first3Incicdents = currentIncidents.slice(0, 3);
     const first3TimelineItems = first3Incicdents.map((incident, i) => {
       return (

--- a/components/status-page.js
+++ b/components/status-page.js
@@ -34,7 +34,8 @@ export default class StatusPage extends React.PureComponent {
     refreshRate: PropTypes.number,
     handleDeleteTileModal: PropTypes.func,
     editHostName: PropTypes.func,
-    setServiceTileRef: PropTypes.object
+    setServiceTileRef: PropTypes.object,
+    accountId: PropTypes.string
   };
 
   constructor(props) {
@@ -49,7 +50,8 @@ export default class StatusPage extends React.PureComponent {
     } else {
       this.StatusPageNetwork = new NRQLHelper(
         this.props.hostname.nrqlQuery,
-        this.props.refreshRate
+        this.props.refreshRate,
+        this.props.accountId
       );
     }
 
@@ -65,6 +67,7 @@ export default class StatusPage extends React.PureComponent {
       settingsPopoverActive: false,
       editedServiceName: this.props.hostname.serviceName,
       editedHostName: this.props.hostname.hostName,
+      editedNrqlQuery: this.props.hostname.nrqlQuery,
       editedHostProvider: this.props.hostname.provider,
       editedHostLogo: this.props.hostname.hostLogo,
       editedHostId: this.props.hostname.id
@@ -248,6 +251,7 @@ export default class StatusPage extends React.PureComponent {
     refreshRate,
     hostname,
     provider,
+    nrqlQuery,
     selectedIndex
   ) {
     if (!event.target.closest('.destructive')) {
@@ -259,6 +263,8 @@ export default class StatusPage extends React.PureComponent {
             refreshRate: refreshRate,
             hostname: hostname,
             provider: provider,
+            nrqlQuery: nrqlQuery,
+            accountId: this.props.accountId,
             timelineItemIndex: selectedIndex
           }
         });
@@ -271,7 +277,9 @@ export default class StatusPage extends React.PureComponent {
             statusPageIoSummaryData: statusPageIoSummaryData,
             refreshRate: refreshRate,
             hostname: hostname,
-            provider: provider
+            provider: provider,
+            nrqlQuery: nrqlQuery,
+            accountId: this.props.accountId
           }
         });
       }
@@ -302,6 +310,7 @@ export default class StatusPage extends React.PureComponent {
       hostName: this.state.editedHostName,
       provider: this.state.editedHostProvider,
       hostLogo: this.state.editedHostLogo,
+      nrqlQuery: this.state.editedNrqlQuery,
       id: this.state.editedHostId
     };
 
@@ -400,55 +409,72 @@ export default class StatusPage extends React.PureComponent {
             }
             defaultValue={hostname.serviceName}
           />
-          <TextField
-            label="Hostname"
-            placeholder="https://status.myservice.com/"
-            className="status-page-setting"
-            onChange={() =>
-              this.setState(previousState => ({
-                ...previousState,
-                editedHostName: event.target.value
-              }))
-            }
-            defaultValue={hostname.hostName}
-          />
-          <Dropdown
-            title="Choose a provider"
-            label="Provider"
-            className="status-page-setting"
-          >
-            <DropdownItem
-              selected
-              onClick={() =>
+          {hostname.provider !== NRQL_PROVIDER_NAME ? (
+            <>
+              <TextField
+                label="Hostname"
+                placeholder="https://status.myservice.com/"
+                className="status-page-setting"
+                onChange={() =>
+                  this.setState(previousState => ({
+                    ...previousState,
+                    editedHostName: event.target.value
+                  }))
+                }
+                defaultValue={hostname.hostName}
+              />
+              <Dropdown
+                title="Choose a provider"
+                label="Provider"
+                className="status-page-setting"
+              >
+                <DropdownItem
+                  selected
+                  onClick={() =>
+                    this.setState(previousState => ({
+                      ...previousState,
+                      editedHostProvider: event.target.innerHTML
+                    }))
+                  }
+                >
+                  Status Page
+                </DropdownItem>
+                <DropdownItem
+                  onClick={() =>
+                    this.setState(previousState => ({
+                      ...previousState,
+                      editedHostProvider: event.target.innerHTML
+                    }))
+                  }
+                >
+                  Google
+                </DropdownItem>
+                <DropdownItem
+                  onClick={() =>
+                    this.setState(previousState => ({
+                      ...previousState,
+                      editedHostProvider: event.target.innerHTML
+                    }))
+                  }
+                >
+                  Status Io
+                </DropdownItem>
+              </Dropdown>
+            </>
+          ) : (
+            <TextField
+              label="NRQL"
+              placeholder="Put your NRQL query here"
+              className="status-page-setting"
+              onChange={() =>
                 this.setState(previousState => ({
                   ...previousState,
-                  editedHostProvider: event.target.innerHTML
+                  editedNrqlQuery: event.target.value
                 }))
               }
-            >
-              Status Page
-            </DropdownItem>
-            <DropdownItem
-              onClick={() =>
-                this.setState(previousState => ({
-                  ...previousState,
-                  editedHostProvider: event.target.innerHTML
-                }))
-              }
-            >
-              Google
-            </DropdownItem>
-            <DropdownItem
-              onClick={() =>
-                this.setState(previousState => ({
-                  ...previousState,
-                  editedHostProvider: event.target.innerHTML
-                }))
-              }
-            >
-              Status Io
-            </DropdownItem>
-          </Dropdown>
+              defaultValue={hostname.nrqlQuery}
+            />
+          )}
           <TextField
             label="Service logo"
             className="status-page-setting"
@@ -497,7 +523,7 @@ export default class StatusPage extends React.PureComponent {
   }
 
   renderSuccessfulState() {
-    const { refreshRate, hostname } = this.props;
+    const { refreshRate, hostname, accountId } = this.props;
     const { statusPageIoSummaryData = {} } = this.state;
 
     return (
@@ -509,7 +535,8 @@ export default class StatusPage extends React.PureComponent {
             statusPageIoSummaryData,
             refreshRate,
             hostname.hostName,
-            hostname.provider
+            hostname.provider,
+            hostname.nrqlQuery
           )
         }
       >
@@ -574,12 +601,15 @@ export default class StatusPage extends React.PureComponent {
           refreshRate={refreshRate}
           hostname={hostname.hostName}
           provider={hostname.provider}
+          accountId={accountId}
+          nrqlQuery={hostname.nrqlQuery}
           handleTileClick={i => {
             this.handleTileClick(
               statusPageIoSummaryData,
               refreshRate,
               hostname.hostName,
               hostname.provider,
+              hostname.nrqlQuery,
               i
             );
           }}

--- a/nerdlets/service-details/index.js
+++ b/nerdlets/service-details/index.js
@@ -13,7 +13,9 @@ export default class ServiceDetailsWrapper extends React.PureComponent {
               provider,
               hostname,
               timelineItemIndex,
-              refreshRate
+              refreshRate,
+              nrqlQuery,
+              accountDetails
             } = nerdletUrlState;
 
             return (
@@ -26,6 +28,8 @@ export default class ServiceDetailsWrapper extends React.PureComponent {
                   provider={provider}
                   refreshRate={refreshRate}
                   timelineItemIndex={timelineItemIndex}
+                  nrqlQuery={nrqlQuery}
+                  accountDetails={accountDetails}
                 />
               </>
             );

--- a/nerdlets/service-details/index.js
+++ b/nerdlets/service-details/index.js
@@ -15,7 +15,7 @@ export default class ServiceDetailsWrapper extends React.PureComponent {
               timelineItemIndex,
               refreshRate,
               nrqlQuery,
-              accountDetails
+              accountId
             } = nerdletUrlState;
 
             return (
@@ -29,7 +29,7 @@ export default class ServiceDetailsWrapper extends React.PureComponent {
                   refreshRate={refreshRate}
                   timelineItemIndex={timelineItemIndex}
                   nrqlQuery={nrqlQuery}
-                  accountDetails={accountDetails}
+                  accountId={accountId}
                 />
               </>
             );

--- a/nerdlets/service-details/service-details.js
+++ b/nerdlets/service-details/service-details.js
@@ -14,9 +14,9 @@ export default class ServiceDetails extends React.PureComponent {
     hostname: PropTypes.string,
     provider: PropTypes.string.isRequired,
     refreshRate: PropTypes.number,
-    timelineItemIndex: PropTypes.object,
+    timelineItemIndex: PropTypes.number,
     nrqlQuery: PropTypes.string,
-    accountId: PropTypes.string
+    accountId: PropTypes.number
   };
 
   constructor(props) {
@@ -39,14 +39,20 @@ export default class ServiceDetails extends React.PureComponent {
   }
 
   componentDidUpdate(prevProps) {
-    const { timelineItemIndex, hostname, refreshRate, provider } = this.props;
+    const {
+      timelineItemIndex,
+      hostname,
+      refreshRate,
+      provider,
+      nrqlQuery
+    } = this.props;
 
     if (prevProps.timelineItemIndex !== timelineItemIndex) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ expandedTimelineItem: timelineItemIndex });
     }
 
-    if (prevProps.hostname !== hostname) {
+    if (prevProps.hostname !== hostname || prevProps.nrqlQuery !== nrqlQuery) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ currentIncidents: undefined });
       this.setupTimelinePolling(hostname, refreshRate, provider);
@@ -58,7 +64,7 @@ export default class ServiceDetails extends React.PureComponent {
 
     this.FormatService = new FormatService(provider);
 
-    if (NRQL_PROVIDER_NAME === provider) {
+    if (provider === NRQL_PROVIDER_NAME) {
       const { nrqlQuery, accountId } = this.props;
       this.statusPageNetwork = new NRQLHelper(
         nrqlQuery,
@@ -122,19 +128,21 @@ export default class ServiceDetails extends React.PureComponent {
   }
 
   buildTimelineItemDetails(incident) {
-    const incident_updates = incident.incident_updates.map(incident_update => {
-      return (
-        <li
-          key={incident_update.created_at}
-          className="timeline-item-contents-item"
-        >
-          <span className="key">
-            {dayjs(incident_update.display_at).format('h:mm a')}:
-          </span>
-          <span className="value">{incident_update.body}</span>
-        </li>
-      );
-    });
+    const incident_updates = incident.incident_updates.map(
+      (incident_update, index) => {
+        return (
+          <li
+            key={`${incident_update.created_at}-${index}`}
+            className="timeline-item-contents-item"
+          >
+            <span className="key">
+              {dayjs(incident_update.display_at).format('h:mm a')}:
+            </span>
+            <span className="value">{incident_update.body}</span>
+          </li>
+        );
+      }
+    );
 
     return incident_updates;
   }

--- a/nerdlets/service-details/service-details.js
+++ b/nerdlets/service-details/service-details.js
@@ -5,13 +5,18 @@ import FormatService from '../../utilities/format-service';
 import dayjs from 'dayjs';
 
 import { Icon, Button } from 'nr1';
+import NRQLHelper from '../../utilities/nrql-helper';
+
+const NRQL_PROVIDER_NAME = 'nrql';
 
 export default class ServiceDetails extends React.PureComponent {
   static propTypes = {
-    hostname: PropTypes.string.isRequired,
+    hostname: PropTypes.string,
     provider: PropTypes.string.isRequired,
     refreshRate: PropTypes.number,
-    timelineItemIndex: PropTypes.object
+    timelineItemIndex: PropTypes.object,
+    nrqlQuery: PropTypes.string,
+    accountId: PropTypes.string
   };
 
   constructor(props) {
@@ -53,7 +58,17 @@ export default class ServiceDetails extends React.PureComponent {
 
     this.FormatService = new FormatService(provider);
 
-    this.statusPageNetwork = new Network(hostname, refreshRate, provider);
+    if (NRQL_PROVIDER_NAME === provider) {
+      const { nrqlQuery, accountId } = this.props;
+      this.statusPageNetwork = new NRQLHelper(
+        nrqlQuery,
+        refreshRate,
+        accountId
+      );
+    } else {
+      this.statusPageNetwork = new Network(hostname, refreshRate, provider);
+    }
+
     this.statusPageNetwork.pollCurrentIncidents(this.setIncidentData);
   };
 

--- a/nerdlets/service-details/service-details.js
+++ b/nerdlets/service-details/service-details.js
@@ -164,7 +164,7 @@ export default class ServiceDetails extends React.PureComponent {
           className={`timeline-item impact-${incident.impact} ${
             expandedTimelineItem === incidentId ? 'timeline-item-expanded' : ''
           }`}
-          key={incident.created_at}
+          key={`${incident.created_at}-${incidentId}`}
         >
           <div className="timeline-item-timestamp">
             <span className="timeline-timestamp-date">

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -317,7 +317,6 @@ export default class StatusPagesDashboard extends React.PureComponent {
       searchQuery,
       hostNames,
       requestForHostnamesMade,
-      keyObject,
       entityGuid
     } = this.state;
 

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -146,11 +146,13 @@ export default class StatusPagesDashboard extends React.PureComponent {
       );
 
       if (!formatRegexp.test(updatedFormInputs.nrqlQuery.inputValue)) {
+        isFormValid = false;
         updatedFormInputs.nrqlQuery.validationText =
           'Provided value is not correct NRQL query';
       } else if (!fieldsRegexp.test(updatedFormInputs.nrqlQuery.inputValue)) {
+        isFormValid = false;
         updatedFormInputs.nrqlQuery.validationText =
-          'Correct query must contain following fields/aliases: EventName, EventStatus and EventTimeStamp';
+          'Query must contain following fields/aliases: EventName, EventStatus and EventTimeStamp';
       }
     }
 
@@ -580,7 +582,7 @@ export default class StatusPagesDashboard extends React.PureComponent {
           />
 
           {providerName.inputValue === PROVIDERS.NRQL.value ? (
-            <div>
+            <>
               <TextFieldWrapper
                 label="NRQL"
                 placeholder="Put your NRQL query here"
@@ -590,13 +592,11 @@ export default class StatusPagesDashboard extends React.PureComponent {
                 value={nrqlQuery.inputValue}
                 validationText={nrqlQuery.validationText}
               />
-              {!nrqlQuery.validationText && (
-                <p>
-                  Correct NRQL query must contain following fields/aliases:
-                  EventName, EventStatus and EventTimeStamp.
-                </p>
-              )}
-            </div>
+              <p>
+                Correct NRQL query must contain following fields/aliases:
+                EventName, EventStatus and EventTimeStamp.
+              </p>
+            </>
           ) : (
             <TextFieldWrapper
               label="Hostname"

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -162,11 +162,11 @@ export default class StatusPagesDashboard extends React.PureComponent {
     } = formInputs;
 
     let formattedHostName;
-    if (providerName !== PROVIDERS.NRQL.value) {
+    if (providerName.inputValue !== PROVIDERS.NRQL.value) {
       const CORSproxy = 'https://cors-anywhere.herokuapp.com/';
       formattedHostName = hostRequiresProxy
         ? `${CORSproxy}${hostName?.inputValue}`
-        : hostName.inputValue;
+        : hostName?.inputValue;
     }
 
     const hostNameObject = {
@@ -236,6 +236,7 @@ export default class StatusPagesDashboard extends React.PureComponent {
 
     if (filledInputs.providerName.inputValue === PROVIDERS.NRQL.value) {
       filledInputs.hostName = { ...emptyInputState };
+      delete filledInputs.nrqlQuery;
     }
 
     filledInputs.hostName.inputValue = selectedPopularSite.hostName;
@@ -391,7 +392,7 @@ export default class StatusPagesDashboard extends React.PureComponent {
           handleDeleteTileModal={() => this.handleDeleteTileModal}
           editHostName={() => this.editHostName}
           setSearchQuery={() => this.setSearchQuery}
-          keyObject={keyObject}
+          accountId={this.state.selectedAccountId}
         />
       </GridItem>
     ));

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -136,6 +136,24 @@ export default class StatusPagesDashboard extends React.PureComponent {
       }
     }
 
+    if (updatedFormInputs.nrqlQuery && updatedFormInputs.nrqlQuery.inputValue) {
+      const formatRegexp = new RegExp(
+        /^((?=.*SELECT.*FROM)|(?=.*FROM.*SELECT)).*$/i
+      );
+
+      const fieldsRegexp = new RegExp(
+        /^.*(?=.*EventName)(?=.*EventStatus)(?=.*EventTimeStamp).*$/
+      );
+
+      if (!formatRegexp.test(updatedFormInputs.nrqlQuery.inputValue)) {
+        updatedFormInputs.nrqlQuery.validationText =
+          'Provided value is not correct NRQL query';
+      } else if (!fieldsRegexp.test(updatedFormInputs.nrqlQuery.inputValue)) {
+        updatedFormInputs.nrqlQuery.validationText =
+          'Correct query must contain following fields/aliases: EventName, EventStatus and EventTimeStamp';
+      }
+    }
+
     if (updatedFormInputs.providerName.inputValue === 'statusIo') {
       const regExp = new RegExp(/\/pages\/history\/[a-z0-9]+$/g);
       if (!regExp.test(updatedFormInputs.hostName.inputValue)) {
@@ -562,15 +580,23 @@ export default class StatusPagesDashboard extends React.PureComponent {
           />
 
           {providerName.inputValue === PROVIDERS.NRQL.value ? (
-            <TextFieldWrapper
-              label="NRQL"
-              placeholder="Put your NRQL query here"
-              onChange={event => {
-                this.updateInputValue(event, 'nrqlQuery');
-              }}
-              value={nrqlQuery.inputValue}
-              validationText={nrqlQuery.validationText}
-            />
+            <div>
+              <TextFieldWrapper
+                label="NRQL"
+                placeholder="Put your NRQL query here"
+                onChange={event => {
+                  this.updateInputValue(event, 'nrqlQuery');
+                }}
+                value={nrqlQuery.inputValue}
+                validationText={nrqlQuery.validationText}
+              />
+              {!nrqlQuery.validationText && (
+                <p>
+                  Correct NRQL query must contain following fields/aliases:
+                  EventName, EventStatus and EventTimeStamp.
+                </p>
+              )}
+            </div>
           ) : (
             <TextFieldWrapper
               label="Hostname"

--- a/nerdlets/status-page-dashboard/styles.scss
+++ b/nerdlets/status-page-dashboard/styles.scss
@@ -602,7 +602,7 @@ button[class*='Dropdown-trigger'],
   border-bottom: 1px solid #edeeee;
   padding: 0 8px;
 
-  .key {  
+  .key {
     margin-right: 8px;
     font-weight: 600;
     color: #464e4e;

--- a/nr1.json
+++ b/nr1.json
@@ -1,6 +1,6 @@
 {
   "schemaType": "NERDPACK",
-  "id": "2522268e-d37f-47db-a9b8-816da0ee2584",
+  "id": "f71018a3-cb76-431a-af7e-74623b1f7c6a",
   "displayName": "Status Pages",
   "description": "Collect and display the statuses of key dependencies in one place"
 }

--- a/popular-status-pages.js
+++ b/popular-status-pages.js
@@ -7,7 +7,7 @@ export const popularSites = {
       hostName: 'https://status.cloud.google.com',
       provider: 'google',
       hostLogo:
-        'https://cloud.google.com/_static/47b8b6d10c/images/cloud/cloud-logo.svg',
+        'https://cloud.google.com/_static/47b8b6d10c/images/cloud/cloud-logo.svg'
     },
     {
       id: 'f10f56ce-a9f1-41b7-8795-f3dc552de84b',
@@ -15,7 +15,7 @@ export const popularSites = {
       hostName: 'https://status.newrelic.com/',
       provider: 'statusPageIo',
       hostLogo:
-        'https://newrelic.com/assets/newrelic/brand/logo-newrelic-068be7f47972f39427fe4a41ad1cad71.svg',
+        'https://newrelic.com/assets/newrelic/brand/logo-newrelic-068be7f47972f39427fe4a41ad1cad71.svg'
     },
     {
       id: '6bec0401-d3e7-4b64-873b-239afc85b110',
@@ -23,7 +23,7 @@ export const popularSites = {
       hostName: 'https://jira-software.status.atlassian.com/',
       provider: 'statusPageIo',
       hostLogo:
-        'https://www.atlassian.com/dam/jcr:e33efd9e-e0b8-4d61-a24d-68a48ef99ed5/Jira%20Software@2x-blue.png',
+        'https://www.atlassian.com/dam/jcr:e33efd9e-e0b8-4d61-a24d-68a48ef99ed5/Jira%20Software@2x-blue.png'
     },
     {
       serviceName: 'GitHub',
@@ -31,7 +31,7 @@ export const popularSites = {
       hostName: 'https://www.githubstatus.com/',
       provider: 'statusPageIo',
       hostLogo:
-        'https://github.githubassets.com/images/modules/logos_page/GitHub-Logo.png',
+        'https://github.githubassets.com/images/modules/logos_page/GitHub-Logo.png'
     },
     {
       serviceName: 'Ezidebit',
@@ -39,7 +39,14 @@ export const popularSites = {
       hostName:
         'https://ezidebit.status.io/pages/history/598a973f96a8201305000142',
       provider: 'statusIo',
-      hostLogo: 'https://image.status.io/rzhxxLCLmUBz.png',
+      hostLogo: 'https://image.status.io/rzhxxLCLmUBz.png'
     },
-  ],
+    {
+      serviceName: 'NRQL',
+      hostname: 'NRQL Query',
+      provider: 'NRQL',
+      hostLogo:
+        'https://newrelic.com/assets/newrelic/brand/logo-newrelic-068be7f47972f39427fe4a41ad1cad71.svg'
+    }
+  ]
 };

--- a/utilities/formatters/nrql.js
+++ b/utilities/formatters/nrql.js
@@ -1,0 +1,44 @@
+const NRQLSeverityToKnown = {
+  None: 'none',
+  Critical: 'critical',
+  Warning: 'minor'
+};
+
+export const nrqlFormatter = data => {
+  let statusCode;
+  let status = 'All Systems Operational';
+  if (data.raw.results[0].events.length === 0) {
+    statusCode = NRQLSeverityToKnown.None;
+  } else {
+    const incident = data.raw.results[0].events[0];
+    statusCode = NRQLSeverityToKnown[incident.EventStatus];
+    if (statusCode !== NRQLSeverityToKnown.None) {
+      status = 'Ongoing Issues';
+    }
+  }
+
+  return {
+    name: 'NRQL',
+    description: status,
+    indicator: statusCode
+  };
+};
+
+export const nrqlIncidentFormatter = data => {
+  return data.raw.results[0].events.map(incident => {
+    const incident_updates = [];
+    Object.entries(incident).forEach(([key, value]) => {
+      incident_updates.push({
+        created_at: incident.EventTimeStamp,
+        body: `${key}: ${value}`
+      });
+    });
+
+    return {
+      name: incident.EventName,
+      created_at: incident.EventTimeStamp,
+      impact: NRQLSeverityToKnown[incident.EventStatus],
+      incident_updates
+    };
+  });
+};

--- a/utilities/formatters/nrql.js
+++ b/utilities/formatters/nrql.js
@@ -7,11 +7,13 @@ const NRQLSeverityToKnown = {
 export const nrqlFormatter = data => {
   let statusCode;
   let status = 'All Systems Operational';
+
   if (data.raw.results[0].events.length === 0) {
     statusCode = NRQLSeverityToKnown.None;
   } else {
     const incident = data.raw.results[0].events[0];
     statusCode = NRQLSeverityToKnown[incident.EventStatus];
+
     if (statusCode !== NRQLSeverityToKnown.None) {
       status = 'Ongoing Issues';
     }
@@ -27,6 +29,7 @@ export const nrqlFormatter = data => {
 export const nrqlIncidentFormatter = data => {
   return data.raw.results[0].events.map(incident => {
     const incident_updates = [];
+
     Object.entries(incident).forEach(([key, value]) => {
       incident_updates.push({
         created_at: incident.EventTimeStamp,

--- a/utilities/formatters/nrql.js
+++ b/utilities/formatters/nrql.js
@@ -5,12 +5,10 @@ const NRQLSeverityToKnown = {
 };
 
 export const nrqlFormatter = data => {
-  let statusCode;
+  let statusCode = NRQLSeverityToKnown.None;
   let status = 'All Systems Operational';
 
-  if (data.raw.results[0].events.length === 0) {
-    statusCode = NRQLSeverityToKnown.None;
-  } else {
+  if (data.raw.results[0].events.length > 0) {
     const incident = data.raw.results[0].events[0];
     statusCode = NRQLSeverityToKnown[incident.EventStatus];
 

--- a/utilities/formatters/status-io.js
+++ b/utilities/formatters/status-io.js
@@ -17,8 +17,6 @@ const StatusIoSeverityToKnown = {
 
 // Example JSON here: https://ezidebit.status.io/1.0/status/598a973f96a8201305000142
 export const statusIoFormatter = data => {
-  // console.debug(data);
-
   const statusCode = data.result.status_overall.status_code;
   const status = data.result.status_overall.status;
 
@@ -30,7 +28,6 @@ export const statusIoFormatter = data => {
 };
 
 export const statusIoIncidentFormatter = data => {
-  // console.log(data);
   return data.result.incidents.map(incident => {
     const firstMessage = incident.messages[0];
 

--- a/utilities/nerdlet-storage.js
+++ b/utilities/nerdlet-storage.js
@@ -10,7 +10,6 @@ const HOST_NAMES_DOCUMENT_ID = 'host_names';
 
 const _getHostNameFromQueryResults = queryResults => {
   if (queryResults.data) {
-    // console.debug(queryResults);
     let hostNames = queryResults.data;
     if (!hostNames) {
       hostNames = [];

--- a/utilities/network.js
+++ b/utilities/network.js
@@ -21,7 +21,6 @@ export default class Network {
   async _fetchAndPopulateData(url, callbackSetterFunction) {
     let networkResponse;
 
-    console.log('polling network');
     try {
       networkResponse = await axios.get(url);
     } catch {

--- a/utilities/network.js
+++ b/utilities/network.js
@@ -7,16 +7,21 @@ export default class Network {
     this.statusPageUrl = statusPageUrl;
     this.refreshRateInSeconds = refreshRateInSeconds;
     this.provider = provider;
-    this.setTimeoutId = undefined;
+    this.setTimeoutIds = [];
   }
 
   clear = () => {
-    clearTimeout(this.setTimeoutId);
+    this.setTimeoutIds.forEach(timeoutId => {
+      clearTimeout(timeoutId);
+    });
+
+    this.setTimeoutIds = [];
   };
 
   async _fetchAndPopulateData(url, callbackSetterFunction) {
     let networkResponse;
 
+    console.log('polling network');
     try {
       networkResponse = await axios.get(url);
     } catch {
@@ -28,7 +33,7 @@ export default class Network {
   }
 
   _pollData(url, callbackSetterFunction, callbackBeforePolling) {
-    this.setTimeoutId = setTimeout(async () => {
+    const setTimeoutId = setTimeout(async () => {
       callbackBeforePolling && callbackBeforePolling();
 
       try {
@@ -39,6 +44,8 @@ export default class Network {
         this._pollData(url, callbackSetterFunction);
       }
     }, this.refreshRateInSeconds * 1000);
+
+    this.setTimeoutIds.push(setTimeoutId);
   }
 
   async pollSummaryData(callbackSetterFunction) {
@@ -54,6 +61,11 @@ export default class Network {
 
     await this._fetchAndPopulateData(url, callbackSetterFunction);
     this._pollData(url, callbackSetterFunction, callbackBeforePolling);
+  }
+
+  checkIfTheSameDataSource() {
+    const provider = getProvider(this.provider);
+    return provider.summaryUrl === provider.incidentUrl;
   }
 
   // helper function to get correct url

--- a/utilities/nrql-helper.js
+++ b/utilities/nrql-helper.js
@@ -1,10 +1,11 @@
 import { NrqlQuery } from 'nr1';
 
 export default class NRQLHelper {
-  constructor(query, refreshRateInSeconds) {
+  constructor(query, refreshRateInSeconds, accountId) {
     this.refreshRateInSeconds = refreshRateInSeconds;
     this.query = query;
     this.setTimeoutId = undefined;
+    this.accountId = accountId;
   }
 
   clear = () => {
@@ -15,17 +16,12 @@ export default class NRQLHelper {
     let networkResponse;
 
     try {
-      // const response = await NrqlQuery.query({
-      //   accountId: 1,
-      //   query:
-      //     'SELECT product, severity, condition_name FROM alert SINCE 1 DAY AGO'
-      // });
-      // console.log('NRQLHelper -> _fetchAndPopulateData -> response', response);
-      // networkResponse = await axios.get(url);
-      networkResponse = 'test';
+      networkResponse = await NrqlQuery.query({
+        accountId: this.accountId,
+        query: this.query,
+        formatType: NrqlQuery.FORMAT_TYPE.RAW
+      });
     } catch (error) {
-      console.log('NRQLHelper -> _fetchAndPopulateData -> error', error);
-
       networkResponse =
         'There was an error while fetching data. Check your data provider or host URL.';
     }

--- a/utilities/nrql-helper.js
+++ b/utilities/nrql-helper.js
@@ -19,7 +19,8 @@ export default class NRQLHelper {
       networkResponse = await NrqlQuery.query({
         accountId: this.accountId,
         query: this.query,
-        formatType: NrqlQuery.FORMAT_TYPE.RAW
+        formatType: NrqlQuery.FORMAT_TYPE.RAW,
+        pollInterval: this.refreshRateInSeconds
       });
     } catch (error) {
       networkResponse =

--- a/utilities/nrql-helper.js
+++ b/utilities/nrql-helper.js
@@ -22,6 +22,10 @@ export default class NRQLHelper {
         formatType: NrqlQuery.FORMAT_TYPE.RAW,
         pollInterval: this.refreshRateInSeconds
       });
+
+      if (networkResponse.data.raw.metadata.messages[0]) {
+        networkResponse = networkResponse.data.raw.metadata.messages[0];
+      }
     } catch (error) {
       networkResponse =
         'There was an error while fetching data. Check your data provider or host URL.';

--- a/utilities/nrql-helper.js
+++ b/utilities/nrql-helper.js
@@ -1,0 +1,59 @@
+import { NrqlQuery } from 'nr1';
+
+export default class NRQLHelper {
+  constructor(query, refreshRateInSeconds) {
+    this.refreshRateInSeconds = refreshRateInSeconds;
+    this.query = query;
+    this.setTimeoutId = undefined;
+  }
+
+  clear = () => {
+    clearTimeout(this.setTimeoutId);
+  };
+
+  async _fetchAndPopulateData(callbackSetterFunction) {
+    let networkResponse;
+
+    try {
+      // const response = await NrqlQuery.query({
+      //   accountId: 1,
+      //   query:
+      //     'SELECT product, severity, condition_name FROM alert SINCE 1 DAY AGO'
+      // });
+      // console.log('NRQLHelper -> _fetchAndPopulateData -> response', response);
+      // networkResponse = await axios.get(url);
+      networkResponse = 'test';
+    } catch (error) {
+      console.log('NRQLHelper -> _fetchAndPopulateData -> error', error);
+
+      networkResponse =
+        'There was an error while fetching data. Check your data provider or host URL.';
+    }
+    callbackSetterFunction(networkResponse);
+    return networkResponse;
+  }
+
+  _pollData(callbackSetterFunction, callbackBeforePolling) {
+    this.setTimeoutId = setTimeout(async () => {
+      callbackBeforePolling && callbackBeforePolling();
+
+      try {
+        this._fetchAndPopulateData(callbackSetterFunction);
+      } catch (err) {
+        console.error(err); // eslint-disable-line no-console
+      } finally {
+        this._pollData(callbackSetterFunction);
+      }
+    }, this.refreshRateInSeconds * 1000);
+  }
+
+  async pollSummaryData(callbackSetterFunction) {
+    await this._fetchAndPopulateData(callbackSetterFunction);
+    this._pollData(callbackSetterFunction);
+  }
+
+  async pollCurrentIncidents(callbackSetterFunction, callbackBeforePolling) {
+    await this._fetchAndPopulateData(callbackSetterFunction);
+    this._pollData(callbackSetterFunction, callbackBeforePolling);
+  }
+}

--- a/utilities/provider-services.js
+++ b/utilities/provider-services.js
@@ -7,6 +7,7 @@ import {
   statusIoIncidentFormatter,
   statusIoFormatter
 } from './formatters/status-io';
+import { nrqlFormatter, nrqlIncidentFormatter } from './formatters/nrql';
 
 const providers = {
   google: {
@@ -46,6 +47,16 @@ const providers = {
     name: 'Status Io',
     summaryFormatter: statusIoFormatter,
     incidentFormatter: statusIoIncidentFormatter
+  },
+  nrql: {
+    impactMap: {
+      warning: 'minor',
+      major: 'major',
+      critical: 'critical'
+    },
+    name: 'NRQL',
+    summaryFormatter: nrqlFormatter,
+    incidentFormatter: nrqlIncidentFormatter
   }
 };
 
@@ -54,6 +65,8 @@ export const getProvider = providerKey => {
     providerKey = 'statusPageIo';
   } else if (providerKey === 'Status Io') {
     providerKey = 'statusIo';
+  } else if (providerKey === 'nrql') {
+    providerKey = 'nrql';
   }
   const provider = providers[providerKey];
   return provider;


### PR DESCRIPTION
Partially closes: #35 and #78 

Polling optimisations made:
- fetch data once and format as summary and recent incidents in main StatusPage component (if possible) using one call
- remove unnecessary Network object initialization in CurrentIncidents and pass incidents from StatusPage
- clear polling when user deletes tile