### PR TITLE
fix: initialize networkResponse

### DIFF
--- a/utilities/rss-helper.js
+++ b/utilities/rss-helper.js
@@ -13,7 +13,7 @@ export default class RSSHelper {
   };
 
   async _fetchAndPopulateData(callbackSetterFunction) {
-    let networkResponse;
+    let networkResponse = {};
 
     try {
       networkResponse.data = await this.parser.parseURL(this.rssUrl);


### PR DESCRIPTION
without initializing `networkResponse` you can't set `data` because `networkResponse` is undefined.