### PR TITLE
Feature: added support for Atom feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ or
 SELECT timestamp as EventTimeStamp, priority as EventStatus, condition_name as EventName, entity.name FROM AlertViolationsSample LIMIT 50
 ```
 
-### RSS feed
+### RSS & Atom feeds
 
-It is possible to choose RSS feed as a provider for status pages.
+It is possible to choose either a RSS or an Atom feed as a provider for status pages.
 
 ### CORS configuration
 

--- a/components/status-page.js
+++ b/components/status-page.js
@@ -49,6 +49,7 @@ const PROVIDERS = [
 
 const NRQL_PROVIDER_NAME = 'nrql';
 const RSS_PROVIDER_NAME = 'rss';
+const ATOM_PROVIDER_NAME = 'atom';
 
 export default class StatusPage extends React.PureComponent {
   static propTypes = {
@@ -613,7 +614,9 @@ export default class StatusPage extends React.PureComponent {
         <div className="logo-container">
           {this.renderSettingsButton()}
           {this.autoSetLogo(hostname)}
-          {hostname.provider === RSS_PROVIDER_NAME && this.renderRssIcon()}
+          {(hostname.provider === RSS_PROVIDER_NAME ||
+            hostname.provider === ATOM_PROVIDER_NAME) &&
+            this.renderRssIcon()}
         </div>
         <div className="service-current-status">
           {statusPageIoSummaryData.link ? (

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -47,6 +47,10 @@ const PROVIDERS = {
   RSS: {
     value: 'rss',
     label: 'RSS Feed'
+  },
+  ATOM: {
+    value: 'atom',
+    label: 'Atom Feed'
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -302,6 +302,11 @@
       "integrity": "sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==",
       "dev": true
     },
+    "addressparser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+      "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y="
+    },
     "aggregate-error": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.0.1.tgz",
@@ -374,6 +379,11 @@
         "define-properties": "^1.1.2",
         "es-abstract": "^1.7.0"
       }
+    },
+    "array-indexofobject": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/array-indexofobject/-/array-indexofobject-0.0.1.tgz",
+      "integrity": "sha1-qqEo5iybPDWAlFaMIZ/2T+SJ1Co="
     },
     "array.prototype.flat": {
       "version": "1.2.3",
@@ -606,6 +616,11 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -1227,6 +1242,22 @@
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
     },
+    "feedparser": {
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/feedparser/-/feedparser-2.2.10.tgz",
+      "integrity": "sha512-WoAOooa61V8/xuKMi2pEtK86qQ3ZH/M72EEGdqlOTxxb3m6ve1NPvZcmPFs3wEDfcBbFLId2GqZ4YjsYi+h1xA==",
+      "requires": {
+        "addressparser": "^1.0.1",
+        "array-indexofobject": "~0.0.1",
+        "lodash.assign": "^4.2.0",
+        "lodash.get": "^4.4.2",
+        "lodash.has": "^4.5.2",
+        "lodash.uniq": "^4.5.0",
+        "mri": "^1.1.5",
+        "readable-stream": "^2.3.7",
+        "sax": "^1.2.4"
+      }
+    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -1674,8 +1705,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -1780,21 +1810,41 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
+    },
     "lodash.unescape": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=",
       "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
+      "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -1862,6 +1912,11 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "mri": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ=="
     },
     "ms": {
       "version": "2.0.0",
@@ -2142,6 +2197,11 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -2260,6 +2320,20 @@
         "read-pkg": "^2.0.0"
       }
     },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "regexpp": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
@@ -2365,6 +2439,11 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -2521,6 +2600,14 @@
       "requires": {
         "define-properties": "^1.1.3",
         "function-bind": "^1.1.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {
@@ -2762,6 +2849,11 @@
       "requires": {
         "punycode": "^2.1.0"
       }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.4.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "axios": "^0.19.2",
     "dayjs": "^1.8.29",
+    "feedparser": "^2.2.10",
     "prop-types": "^15.6.2",
     "react": "^16.6.3",
     "react-dom": "^16.6.3",

--- a/utilities/formatters/atom.js
+++ b/utilities/formatters/atom.js
@@ -1,0 +1,39 @@
+const FeedParser = require('feedparser');
+
+export const atomFormatter = data => {
+  const feedparser = new FeedParser();
+  feedparser.write(data);
+
+  return {
+    name: feedparser.meta.title,
+    description: feedparser.meta.description,
+    indicator: 'UnKnown',
+    link: feedparser.meta.link
+  };
+};
+
+export const atomIncidentFormatter = data => {
+  const feedparser = new FeedParser();
+  feedparser.write(data);
+  const incidents = [];
+  let item;
+  while ((item = feedparser.read())) {
+    incidents.push({
+      name: item.title,
+      created_at: item.date,
+      impact: 'unknown',
+      incident_updates: [
+        {
+          created_at: item.date,
+          body: `Link: ${item.link}`
+        },
+        {
+          created_at: item.date,
+          body: `Description: ${item.description}`
+        }
+      ]
+    });
+  }
+
+  return incidents;
+};

--- a/utilities/provider-services.js
+++ b/utilities/provider-services.js
@@ -9,6 +9,7 @@ import {
 } from './formatters/status-io';
 import { nrqlFormatter, nrqlIncidentFormatter } from './formatters/nrql';
 import { rssFormatter, rssIncidentFormatter } from './formatters/rss';
+import { atomFormatter, atomIncidentFormatter } from './formatters/atom';
 
 const providers = {
   google: {
@@ -68,6 +69,18 @@ const providers = {
     name: 'RSS Feed',
     summaryFormatter: rssFormatter,
     incidentFormatter: rssIncidentFormatter
+  },
+  atom: {
+    summaryUrl: '',
+    incidentUrl: '',
+    impactMap: {
+      warning: 'minor',
+      major: 'major',
+      critical: 'critical'
+    },
+    name: 'Atom Feed',
+    summaryFormatter: atomFormatter,
+    incidentFormatter: atomIncidentFormatter
   }
 };
 


### PR DESCRIPTION
When setting up a status page for Babylon, I found one of our dependencies (Auth0) provided an Atom feed, but not an RSS feed.

I have tried to add the functionality in keeping with the style of the rest of the app, but I am not a regular JS developer, so please feel free to critique the style. 