### PR TITLE
Added support for Statuspal

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Example hostnames:
 - [https://ezidebit.status.io/pages/history/598a973f96a8201305000142](https://ezidebit.status.io/pages/history/598a973f96a8201305000142)
 - [https://status.docker.com/pages/history/533c6539221ae15e3f000031](https://status.docker.com/pages/history/533c6539221ae15e3f000031)
 
+### [Statuspal.io](https://statuspal.io)
+
+Example subdomains:
+
+- [galaxygate](https://status.galaxygate.net/) --> From https://status.galaxygate.net/
+- [smtp](https://smtp.statuspal.io) --> From https://smtp.statuspal.io
+
+
 ### NRQL query
 
 NRQL query requires three fields/aliases to be returned: *EventTimeStamp, EventStatus, EventName*.

--- a/components/status-page.js
+++ b/components/status-page.js
@@ -109,7 +109,12 @@ export default class StatusPage extends React.PureComponent {
     this.stopPollingData();
 
     const { refreshRate, accountId } = this.props;
-    const { editedHostProvider, editedHostName, editedNrqlQuery, editedSubDomain } = this.state;
+    const {
+      editedHostProvider,
+      editedHostName,
+      editedNrqlQuery,
+      editedSubDomain
+    } = this.state;
 
     if (editedHostProvider === NRQL_PROVIDER_NAME) {
       this.StatusPageNetwork = new NRQLHelper(
@@ -124,7 +129,10 @@ export default class StatusPage extends React.PureComponent {
 
       this.StatusPageNetwork.pollCurrentIncidents(this.setData);
     } else if (editedHostProvider === STATUSPAL_PROVIDER_NAME) {
-      this.StatusPageNetwork = new StatuspalHelper(editedSubDomain, refreshRate);
+      this.StatusPageNetwork = new StatuspalHelper(
+        editedSubDomain,
+        refreshRate
+      );
 
       this.StatusPageNetwork.pollCurrentIncidents(this.setData);
     } else {

--- a/components/status-page.js
+++ b/components/status-page.js
@@ -5,6 +5,7 @@ import 'web-animations-js';
 import Network from '../utilities/network';
 import NRQLHelper from '../utilities/nrql-helper';
 import RSSHelper from '../utilities/rss-helper';
+import StatuspalHelper from '../utilities/statuspal-helper';
 import CurrentIncidents from './current-incidents';
 import FormatService from '../utilities/format-service';
 import {
@@ -44,11 +45,16 @@ const PROVIDERS = [
   {
     value: 'rss',
     label: 'RSS Feed'
+  },
+  {
+    value: 'statusPal',
+    label: 'Statuspal'
   }
 ];
 
 const NRQL_PROVIDER_NAME = 'nrql';
 const RSS_PROVIDER_NAME = 'rss';
+const STATUSPAL_PROVIDER_NAME = 'statusPal';
 
 export default class StatusPage extends React.PureComponent {
   static propTypes = {
@@ -75,6 +81,7 @@ export default class StatusPage extends React.PureComponent {
       editedServiceName: this.props.hostname.serviceName,
       editedHostName: this.props.hostname.hostName,
       editedNrqlQuery: this.props.hostname.nrqlQuery,
+      editedSubDomain: this.props.hostname.subDomain,
       editedHostProvider: this.props.hostname.provider,
       editedHostLogo: this.props.hostname.hostLogo,
       editedHostId: this.props.hostname.id
@@ -102,7 +109,7 @@ export default class StatusPage extends React.PureComponent {
     this.stopPollingData();
 
     const { refreshRate, accountId } = this.props;
-    const { editedHostProvider, editedHostName, editedNrqlQuery } = this.state;
+    const { editedHostProvider, editedHostName, editedNrqlQuery, editedSubDomain } = this.state;
 
     if (editedHostProvider === NRQL_PROVIDER_NAME) {
       this.StatusPageNetwork = new NRQLHelper(
@@ -114,6 +121,10 @@ export default class StatusPage extends React.PureComponent {
       this.StatusPageNetwork.pollCurrentIncidents(this.setData);
     } else if (editedHostProvider === RSS_PROVIDER_NAME) {
       this.StatusPageNetwork = new RSSHelper(editedHostName, refreshRate);
+
+      this.StatusPageNetwork.pollCurrentIncidents(this.setData);
+    } else if (editedHostProvider === STATUSPAL_PROVIDER_NAME) {
+      this.StatusPageNetwork = new StatuspalHelper(editedSubDomain, refreshRate);
 
       this.StatusPageNetwork.pollCurrentIncidents(this.setData);
     } else {
@@ -323,6 +334,7 @@ export default class StatusPage extends React.PureComponent {
     hostname,
     provider,
     nrqlQuery,
+    subDomain,
     selectedIndex
   ) {
     if (!event.target.closest('.destructive')) {
@@ -335,6 +347,7 @@ export default class StatusPage extends React.PureComponent {
             hostname: hostname,
             provider: provider,
             nrqlQuery: this.state.editedNrqlQuery,
+            subDomain: this.state.editedSubDomain,
             accountId: this.props.accountId,
             timelineItemIndex: selectedIndex
           }
@@ -350,6 +363,7 @@ export default class StatusPage extends React.PureComponent {
             hostname: hostname,
             provider: provider,
             nrqlQuery: nrqlQuery,
+            subDomain: subDomain,
             accountId: this.props.accountId
           }
         });
@@ -382,6 +396,7 @@ export default class StatusPage extends React.PureComponent {
       provider: this.state.editedHostProvider,
       hostLogo: this.state.editedHostLogo,
       nrqlQuery: this.state.editedNrqlQuery,
+      subDomain: this.state.editedSubDomain,
       id: this.state.editedHostId
     };
 
@@ -496,18 +511,34 @@ export default class StatusPage extends React.PureComponent {
             />
           ) : (
             <>
-              <TextField
-                label="Hostname"
-                placeholder="https://status.myservice.com/"
-                className="status-page-setting"
-                onChange={() =>
-                  this.setState(previousState => ({
-                    ...previousState,
-                    editedHostName: event.target.value
-                  }))
-                }
-                defaultValue={hostname.hostName}
-              />
+              {hostname.provider === STATUSPAL_PROVIDER_NAME ? (
+                <TextField
+                  label="Subdomain"
+                  placeholder="myservice.com"
+                  className="status-page-setting"
+                  onChange={() =>
+                    this.setState(previousState => ({
+                      ...previousState,
+                      editedSubDomain: event.target.value
+                    }))
+                  }
+                  defaultValue={hostname.subDomain}
+                />
+              ) : (
+                <TextField
+                  label="Hostname"
+                  placeholder="https://status.myservice.com/"
+                  className="status-page-setting"
+                  onChange={() =>
+                    this.setState(previousState => ({
+                      ...previousState,
+                      editedHostName: event.target.value
+                    }))
+                  }
+                  defaultValue={hostname.hostName}
+                />
+              )}
+
               <Dropdown
                 title={
                   PROVIDERS.find(
@@ -606,7 +637,8 @@ export default class StatusPage extends React.PureComponent {
             refreshRate,
             this.state.editedHostName,
             this.state.editedHostProvider,
-            this.state.editedNrqlQuery
+            this.state.editedNrqlQuery,
+            this.state.editedSubDomain
           )
         }
       >
@@ -684,6 +716,7 @@ export default class StatusPage extends React.PureComponent {
           provider={hostname.provider}
           accountId={accountId}
           nrqlQuery={hostname.nrqlQuery}
+          subDomain={hostname.subDomain}
           handleTileClick={i => {
             this.handleTileClick(
               statusPageIoSummaryData,
@@ -691,6 +724,7 @@ export default class StatusPage extends React.PureComponent {
               this.state.editedHostName,
               this.state.editedHostProvider,
               this.state.editedNrqlQuery,
+              this.state.editedSubDomain,
               i
             );
           }}

--- a/nerdlets/service-details/index.js
+++ b/nerdlets/service-details/index.js
@@ -15,6 +15,7 @@ export default class ServiceDetailsWrapper extends React.PureComponent {
               timelineItemIndex,
               refreshRate,
               nrqlQuery,
+              subDomain,
               accountId
             } = nerdletUrlState;
 
@@ -29,6 +30,7 @@ export default class ServiceDetailsWrapper extends React.PureComponent {
                   refreshRate={refreshRate}
                   timelineItemIndex={timelineItemIndex}
                   nrqlQuery={nrqlQuery}
+                  subDomain={subDomain}
                   accountId={accountId}
                 />
               </>

--- a/nerdlets/service-details/service-details.js
+++ b/nerdlets/service-details/service-details.js
@@ -13,7 +13,6 @@ const NRQL_PROVIDER_NAME = 'nrql';
 const RSS_PROVIDER_NAME = 'rss';
 const STATUSPAL_PROVIDER_NAME = 'statusPal';
 
-
 export default class ServiceDetails extends React.PureComponent {
   static propTypes = {
     hostname: PropTypes.string,
@@ -59,7 +58,11 @@ export default class ServiceDetails extends React.PureComponent {
       this.setState({ expandedTimelineItem: timelineItemIndex });
     }
 
-    if (prevProps.hostname !== hostname || prevProps.subDomain !== subDomain || prevProps.nrqlQuery !== nrqlQuery) {
+    if (
+      prevProps.hostname !== hostname ||
+      prevProps.subDomain !== subDomain ||
+      prevProps.nrqlQuery !== nrqlQuery
+    ) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ currentIncidents: undefined });
       this.setupTimelinePolling(hostname, refreshRate, provider);
@@ -81,7 +84,10 @@ export default class ServiceDetails extends React.PureComponent {
     } else if (provider === RSS_PROVIDER_NAME) {
       this.statusPageNetwork = new RSSHelper(hostname, refreshRate);
     } else if (provider === STATUSPAL_PROVIDER_NAME) {
-      this.statusPageNetwork = new StatuspalHelper(this.props.subDomain, refreshRate);
+      this.statusPageNetwork = new StatuspalHelper(
+        this.props.subDomain,
+        refreshRate
+      );
     } else {
       this.statusPageNetwork = new Network(hostname, refreshRate, provider);
     }

--- a/nerdlets/service-details/service-details.js
+++ b/nerdlets/service-details/service-details.js
@@ -7,9 +7,12 @@ import dayjs from 'dayjs';
 import { Icon, Button } from 'nr1';
 import NRQLHelper from '../../utilities/nrql-helper';
 import RSSHelper from '../../utilities/rss-helper';
+import StatuspalHelper from '../../utilities/statuspal-helper';
 
 const NRQL_PROVIDER_NAME = 'nrql';
 const RSS_PROVIDER_NAME = 'rss';
+const STATUSPAL_PROVIDER_NAME = 'statusPal';
+
 
 export default class ServiceDetails extends React.PureComponent {
   static propTypes = {
@@ -18,6 +21,7 @@ export default class ServiceDetails extends React.PureComponent {
     refreshRate: PropTypes.number,
     timelineItemIndex: PropTypes.number,
     nrqlQuery: PropTypes.string,
+    subDomain: PropTypes.string,
     accountId: PropTypes.number
   };
 
@@ -46,7 +50,8 @@ export default class ServiceDetails extends React.PureComponent {
       hostname,
       refreshRate,
       provider,
-      nrqlQuery
+      nrqlQuery,
+      subDomain
     } = this.props;
 
     if (prevProps.timelineItemIndex !== timelineItemIndex) {
@@ -54,7 +59,7 @@ export default class ServiceDetails extends React.PureComponent {
       this.setState({ expandedTimelineItem: timelineItemIndex });
     }
 
-    if (prevProps.hostname !== hostname || prevProps.nrqlQuery !== nrqlQuery) {
+    if (prevProps.hostname !== hostname || prevProps.subDomain !== subDomain || prevProps.nrqlQuery !== nrqlQuery) {
       // eslint-disable-next-line react/no-did-update-set-state
       this.setState({ currentIncidents: undefined });
       this.setupTimelinePolling(hostname, refreshRate, provider);
@@ -75,6 +80,8 @@ export default class ServiceDetails extends React.PureComponent {
       );
     } else if (provider === RSS_PROVIDER_NAME) {
       this.statusPageNetwork = new RSSHelper(hostname, refreshRate);
+    } else if (provider === STATUSPAL_PROVIDER_NAME) {
+      this.statusPageNetwork = new StatuspalHelper(this.props.subDomain, refreshRate);
     } else {
       this.statusPageNetwork = new Network(hostname, refreshRate, provider);
     }

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -47,6 +47,10 @@ const PROVIDERS = {
   RSS: {
     value: 'rss',
     label: 'RSS Feed'
+  },
+  STATUS_PAL: {
+    value: 'statusPal',
+    label: 'Statuspal'
   }
 };
 
@@ -119,6 +123,7 @@ export default class StatusPagesDashboard extends React.PureComponent {
     });
 
     delete updatedInputs.nrqlQuery;
+    delete updatedInputs.subDomain;
     updatedInputs.hostName = { ...emptyInputState };
 
     this.setState({ formInputs: updatedInputs, selectedPopularSiteIndex: '' });
@@ -196,11 +201,12 @@ export default class StatusPagesDashboard extends React.PureComponent {
       providerName,
       logoUrl,
       nrqlQuery,
-      corsProxyAddress
+      corsProxyAddress,
+      subDomain
     } = formInputs;
 
     let formattedHostName;
-    if (providerName.inputValue !== PROVIDERS.NRQL.value) {
+    if (providerName.inputValue !== PROVIDERS.NRQL.value && providerName.inputValue !== PROVIDERS.STATUS_PAL.inputValue) {
       formattedHostName = hostRequiresProxy
         ? corsProxyAddress.inputValue.replace('{url}', hostName?.inputValue)
         : hostName?.inputValue;
@@ -214,7 +220,8 @@ export default class StatusPagesDashboard extends React.PureComponent {
       hostName: formattedHostName,
       provider: providerName.inputValue,
       hostLogo: logoUrl.inputValue,
-      nrqlQuery: nrqlQuery?.inputValue
+      nrqlQuery: nrqlQuery?.inputValue,
+      subDomain: subDomain?.inputValue
     };
 
     await this.addHostName(hostNameObject);
@@ -339,6 +346,9 @@ export default class StatusPagesDashboard extends React.PureComponent {
       if (updatedFormInputs.providerName.inputValue === PROVIDERS.NRQL.value) {
         delete updatedFormInputs.hostName;
         updatedFormInputs.nrqlQuery = { ...emptyInputState };
+      } else if (updatedFormInputs.providerName.inputValue === PROVIDERS.STATUS_PAL.value) {
+        delete updatedFormInputs.hostName;
+        updatedFormInputs.subDomain = { ...emptyInputState };
       } else {
         delete updatedFormInputs.nrqlQuery;
         updatedFormInputs.hostName = { ...emptyInputState };
@@ -503,7 +513,8 @@ export default class StatusPagesDashboard extends React.PureComponent {
       providerName,
       logoUrl,
       nrqlQuery,
-      corsProxyAddress
+      corsProxyAddress,
+      subDomain
     } = formInputs;
 
     return (
@@ -633,7 +644,6 @@ export default class StatusPagesDashboard extends React.PureComponent {
           />
 
           {providerName.inputValue === PROVIDERS.NRQL.value ? (
-            <>
               <TextFieldWrapper
                 label="NRQL"
                 placeholder="Put your NRQL query here"
@@ -643,11 +653,16 @@ export default class StatusPagesDashboard extends React.PureComponent {
                 value={nrqlQuery.inputValue}
                 validationText={nrqlQuery.validationText}
               />
-              <p>
-                Correct NRQL query must contain following fields/aliases:
-                EventName, EventStatus and EventTimeStamp.
-              </p>
-            </>
+          ) : providerName.inputValue === PROVIDERS.STATUS_PAL.value ?  (
+              <TextFieldWrapper
+                label="Subdomain"
+                placeholder="Put your Statuspal subdomain here"
+                onChange={event => {
+                  this.updateInputValue(event, 'subDomain');
+                }}
+                value={subDomain.inputValue}
+                validationText={subDomain.validationText}
+              />
           ) : (
             <TextFieldWrapper
               label="Hostname"

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -205,13 +205,9 @@ export default class StatusPagesDashboard extends React.PureComponent {
       subDomain
     } = formInputs;
 
-    if (providerName.inputValue === PROVIDERS.STATUS_PAL.value) {
-      hostname = `https://${subDomain}.statuspal.io`;
-    }
-
     let formattedHostName;
     if (providerName.inputValue === PROVIDERS.STATUS_PAL.value) {
-      formattedHostName = encodeURI(`https://${subDomain}.statuspal.io`);
+      formattedHostName = encodeURI(`https://${subDomain.inputValue}.statuspal.io`);
     } else if (providerName.inputValue !== PROVIDERS.NRQL.value) {
       formattedHostName = hostRequiresProxy
         ? corsProxyAddress.inputValue.replace('{url}', hostName?.inputValue)

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -205,11 +205,14 @@ export default class StatusPagesDashboard extends React.PureComponent {
       subDomain
     } = formInputs;
 
+    if (providerName.inputValue === PROVIDERS.STATUS_PAL.value) {
+      hostname = `https://${subDomain}.statuspal.io`;
+    }
+
     let formattedHostName;
-    if (
-      providerName.inputValue !== PROVIDERS.NRQL.value &&
-      providerName.inputValue !== PROVIDERS.STATUS_PAL.inputValue
-    ) {
+    if (providerName.inputValue === PROVIDERS.STATUS_PAL.value) {
+      formattedHostName = encodeURI(`https://${subDomain}.statuspal.io`);
+    } else if (providerName.inputValue !== PROVIDERS.NRQL.value) {
       formattedHostName = hostRequiresProxy
         ? corsProxyAddress.inputValue.replace('{url}', hostName?.inputValue)
         : hostName?.inputValue;

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -207,7 +207,9 @@ export default class StatusPagesDashboard extends React.PureComponent {
 
     let formattedHostName;
     if (providerName.inputValue === PROVIDERS.STATUS_PAL.value) {
-      formattedHostName = encodeURI(`https://${subDomain.inputValue}.statuspal.io`);
+      formattedHostName = encodeURI(
+        `https://${subDomain.inputValue}.statuspal.io`
+      );
     } else if (providerName.inputValue !== PROVIDERS.NRQL.value) {
       formattedHostName = hostRequiresProxy
         ? corsProxyAddress.inputValue.replace('{url}', hostName?.inputValue)

--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -206,7 +206,10 @@ export default class StatusPagesDashboard extends React.PureComponent {
     } = formInputs;
 
     let formattedHostName;
-    if (providerName.inputValue !== PROVIDERS.NRQL.value && providerName.inputValue !== PROVIDERS.STATUS_PAL.inputValue) {
+    if (
+      providerName.inputValue !== PROVIDERS.NRQL.value &&
+      providerName.inputValue !== PROVIDERS.STATUS_PAL.inputValue
+    ) {
       formattedHostName = hostRequiresProxy
         ? corsProxyAddress.inputValue.replace('{url}', hostName?.inputValue)
         : hostName?.inputValue;
@@ -346,7 +349,9 @@ export default class StatusPagesDashboard extends React.PureComponent {
       if (updatedFormInputs.providerName.inputValue === PROVIDERS.NRQL.value) {
         delete updatedFormInputs.hostName;
         updatedFormInputs.nrqlQuery = { ...emptyInputState };
-      } else if (updatedFormInputs.providerName.inputValue === PROVIDERS.STATUS_PAL.value) {
+      } else if (
+        updatedFormInputs.providerName.inputValue === PROVIDERS.STATUS_PAL.value
+      ) {
         delete updatedFormInputs.hostName;
         updatedFormInputs.subDomain = { ...emptyInputState };
       } else {
@@ -643,26 +648,27 @@ export default class StatusPagesDashboard extends React.PureComponent {
             validationText={serviceName.validationText}
           />
 
-          {providerName.inputValue === PROVIDERS.NRQL.value ? (
-              <TextFieldWrapper
-                label="NRQL"
-                placeholder="Put your NRQL query here"
-                onChange={event => {
-                  this.updateInputValue(event, 'nrqlQuery');
-                }}
-                value={nrqlQuery.inputValue}
-                validationText={nrqlQuery.validationText}
-              />
-          ) : providerName.inputValue === PROVIDERS.STATUS_PAL.value ?  (
-              <TextFieldWrapper
-                label="Subdomain"
-                placeholder="Put your Statuspal subdomain here"
-                onChange={event => {
-                  this.updateInputValue(event, 'subDomain');
-                }}
-                value={subDomain.inputValue}
-                validationText={subDomain.validationText}
-              />
+          {providerName.inputValue === PROVIDERS.NRQL.value && (
+            <TextFieldWrapper
+              label="NRQL"
+              placeholder="Put your NRQL query here"
+              onChange={event => {
+                this.updateInputValue(event, 'nrqlQuery');
+              }}
+              value={nrqlQuery.inputValue}
+              validationText={nrqlQuery.validationText}
+            />
+          )}
+          {providerName.inputValue === PROVIDERS.STATUS_PAL.value ? (
+            <TextFieldWrapper
+              label="Subdomain"
+              placeholder="Put your Statuspal subdomain here"
+              onChange={event => {
+                this.updateInputValue(event, 'subDomain');
+              }}
+              value={subDomain.inputValue}
+              validationText={subDomain.validationText}
+            />
           ) : (
             <TextFieldWrapper
               label="Hostname"

--- a/nr1.json
+++ b/nr1.json
@@ -1,6 +1,6 @@
 {
   "schemaType": "NERDPACK",
-  "id": "3ccfc706-7c42-455c-8015-121e9ffdac3d",
+  "id": "45e228ec-a487-4bee-bbe0-e28d747ed95e",
   "displayName": "Status Pages",
   "description": "Collect and display the statuses of key dependencies in one place"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nr1-status-pages",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "nr1-status-pages",
   "description": "Nerdpack nr1-status-pages",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "bugs": {
     "email": "opensource+nr1-status-pages@newrelic.com"
   },

--- a/utilities/formatters/status-pal.js
+++ b/utilities/formatters/status-pal.js
@@ -1,9 +1,9 @@
 const StatuspalDescriptionMap = {
-  null: "All Systems Operational",
-  "minor": "Minor System Outage",
-  "major": "Major System Outage",
-  "maintenance": "Service Under Maintenance"
-}
+  null: 'All Systems Operational',
+  minor: 'Minor System Outage',
+  major: 'Major System Outage',
+  maintenance: 'Service Under Maintenance'
+};
 
 export const statusPalFormatter = data => {
   data = remapData(data).status;
@@ -13,7 +13,7 @@ export const statusPalFormatter = data => {
   return {
     name: data.status_page.name,
     description: StatuspalDescriptionMap[status],
-    indicator: status === null ? "none" : status
+    indicator: status === null ? 'none' : status
   };
 };
 
@@ -27,14 +27,14 @@ export const statusPalIncidentFormatter = data => {
       impact: incident.type,
       incident_updates: []
     };
-  });;
+  });
 };
 
 function remapData(data) {
   const obj = {};
 
   for (const key of Object.keys(data)) {
-    const urlPaths = key.split("/");
+    const urlPaths = key.split('/');
 
     obj[urlPaths[urlPaths.length - 1]] = data[key];
   }

--- a/utilities/formatters/status-pal.js
+++ b/utilities/formatters/status-pal.js
@@ -1,0 +1,43 @@
+const StatuspalDescriptionMap = {
+  null: "All Systems Operational",
+  "minor": "Minor System Outage",
+  "major": "Major System Outage",
+  "maintenance": "Service Under Maintenance"
+}
+
+export const statusPalFormatter = data => {
+  data = remapData(data).status;
+
+  const status = data.status_page.current_incident_type;
+
+  return {
+    name: data.status_page.name,
+    description: StatuspalDescriptionMap[status],
+    indicator: status === null ? "none" : status
+  };
+};
+
+export const statusPalIncidentFormatter = data => {
+  data = remapData(data).incidents;
+
+  return data.incidents.map(incident => {
+    return {
+      name: incident.title,
+      created_at: incident.inserted_at,
+      impact: incident.type,
+      incident_updates: []
+    };
+  });;
+};
+
+function remapData(data) {
+  const obj = {};
+
+  for (const key of Object.keys(data)) {
+    const urlPaths = key.split("/");
+
+    obj[urlPaths[urlPaths.length - 1]] = data[key];
+  }
+
+  return obj;
+}

--- a/utilities/provider-services.js
+++ b/utilities/provider-services.js
@@ -9,7 +9,10 @@ import {
 } from './formatters/status-io';
 import { nrqlFormatter, nrqlIncidentFormatter } from './formatters/nrql';
 import { rssFormatter, rssIncidentFormatter } from './formatters/rss';
-import { statusPalFormatter, statusPalIncidentFormatter } from './formatters/status-pal';
+import {
+  statusPalFormatter,
+  statusPalIncidentFormatter
+} from './formatters/status-pal';
 
 const providers = {
   google: {

--- a/utilities/provider-services.js
+++ b/utilities/provider-services.js
@@ -9,6 +9,7 @@ import {
 } from './formatters/status-io';
 import { nrqlFormatter, nrqlIncidentFormatter } from './formatters/nrql';
 import { rssFormatter, rssIncidentFormatter } from './formatters/rss';
+import { statusPalFormatter, statusPalIncidentFormatter } from './formatters/status-pal';
 
 const providers = {
   google: {
@@ -68,6 +69,17 @@ const providers = {
     name: 'RSS Feed',
     summaryFormatter: rssFormatter,
     incidentFormatter: rssIncidentFormatter
+  },
+  statusPal: {
+    impactMap: {
+      minor: 'minor',
+      major: 'major',
+      maintence: 'maintence'
+    },
+    apiURL: 'https://cors-anywhere.herokuapp.com/statuspal.io/api/v1',
+    name: 'Statuspal',
+    summaryFormatter: statusPalFormatter,
+    incidentFormatter: statusPalIncidentFormatter
   }
 };
 
@@ -80,6 +92,8 @@ export const getProvider = providerKey => {
     providerKey = 'nrql';
   } else if (providerKey === 'rss') {
     providerKey = 'rss';
+  } else if (providerKey === 'Statuspal') {
+    providerKey = 'statusPal';
   }
   return providers[providerKey];
 };

--- a/utilities/statuspal-helper.js
+++ b/utilities/statuspal-helper.js
@@ -3,22 +3,18 @@ import { getProvider } from './provider-services';
 const axios = require('axios');
 
 const axiosConfig = {
-  method: "GET",
-  mode: "no-cors",
   headers: {
-    "Access-Control-Allow-Origin": "*",
-    "Content-Type": "application/json",
-    "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, OPTIONS"
+    'Access-Control-Allow-Origin': '*'
   }
 };
 
 const STATUSPAL_API = getProvider('statusPal').apiURL;
 
 export default class StatuspalHelper {
-  constructor(subDomain, refreshRateInSeconds) {
+  constructor(subDomain) {
     this.subDomain = subDomain;
-    this.refreshRateInSeconds = 30; //Set to 30 seconds to be under the request limit of cors-anywhere
-                                    //the StatusPal API may change in the feature
+    this.refreshRateInSeconds = 30; // Set to 30 seconds to be under the request limit of cors-anywhere
+    // the StatusPal API may change in the feature
     this.setIntervalIds = [];
   }
 
@@ -34,16 +30,20 @@ export default class StatuspalHelper {
     let networkResponse;
 
     try {
-      const data = await Promise.all(urls.map(async url => {
-        const res = await axios.get(STATUSPAL_API + url, axiosConfig);
+      const data = await Promise.all(
+        urls.map(async url => {
+          const res = await axios.get(STATUSPAL_API + url, axiosConfig);
 
-        return { data: res.data, url };
-      }));
+          return { data: res.data, url };
+        })
+      );
 
-      networkResponse = { data: Object.fromEntries(data.map(data => [ data.url, data.data ])) };
+      networkResponse = {
+        data: Object.fromEntries(data.map(data => [data.url, data.data]))
+      };
     } catch {
       networkResponse =
-        "There was an error while fetching data. Check your data provider or host URL.";
+        'There was an error while fetching data. Check your data provider or host URL.';
     }
 
     callbackSetterFunction(networkResponse);
@@ -66,7 +66,7 @@ export default class StatuspalHelper {
 
   async pollSummaryData(callbackSetterFunction) {
     // Populate initial data before we start polling
-    const urls = [ `/status_pages/${this.subDomain}/status` ];
+    const urls = [`/status_pages/${this.subDomain}/status`];
 
     await this._fetchAndPopulateData(urls, callbackSetterFunction);
     this._pollData(urls, callbackSetterFunction);

--- a/utilities/statuspal-helper.js
+++ b/utilities/statuspal-helper.js
@@ -2,12 +2,6 @@ import { getProvider } from './provider-services';
 
 const axios = require('axios');
 
-const axiosConfig = {
-  headers: {
-    'Access-Control-Allow-Origin': '*'
-  }
-};
-
 const STATUSPAL_API = getProvider('statusPal').apiURL;
 
 export default class StatuspalHelper {
@@ -32,7 +26,7 @@ export default class StatuspalHelper {
     try {
       const data = await Promise.all(
         urls.map(async url => {
-          const res = await axios.get(STATUSPAL_API + url, axiosConfig);
+          const res = await axios.get(STATUSPAL_API + url);
 
           return { data: res.data, url };
         })

--- a/utilities/statuspal-helper.js
+++ b/utilities/statuspal-helper.js
@@ -1,0 +1,84 @@
+import { getProvider } from './provider-services';
+
+const axios = require('axios');
+
+const axiosConfig = {
+  method: "GET",
+  mode: "no-cors",
+  headers: {
+    "Access-Control-Allow-Origin": "*",
+    "Content-Type": "application/json",
+    "Access-Control-Allow-Methods": "GET, PUT, POST, DELETE, OPTIONS"
+  }
+};
+
+const STATUSPAL_API = getProvider('statusPal').apiURL;
+
+export default class StatuspalHelper {
+  constructor(subDomain, refreshRateInSeconds) {
+    this.subDomain = subDomain;
+    this.refreshRateInSeconds = 30; //Set to 30 seconds to be under the request limit of cors-anywhere
+                                    //the StatusPal API may change in the feature
+    this.setIntervalIds = [];
+  }
+
+  clear = () => {
+    this.setIntervalIds.forEach(timeoutId => {
+      clearInterval(timeoutId);
+    });
+
+    this.setIntervalIds = [];
+  };
+
+  async _fetchAndPopulateData(urls, callbackSetterFunction) {
+    let networkResponse;
+
+    try {
+      const data = await Promise.all(urls.map(async url => {
+        const res = await axios.get(STATUSPAL_API + url, axiosConfig);
+
+        return { data: res.data, url };
+      }));
+
+      networkResponse = { data: Object.fromEntries(data.map(data => [ data.url, data.data ])) };
+    } catch {
+      networkResponse =
+        "There was an error while fetching data. Check your data provider or host URL.";
+    }
+
+    callbackSetterFunction(networkResponse);
+    return networkResponse;
+  }
+
+  _pollData(url, callbackSetterFunction, callbackBeforePolling) {
+    const setIntervalId = setInterval(async () => {
+      callbackBeforePolling && callbackBeforePolling();
+
+      try {
+        this._fetchAndPopulateData(url, callbackSetterFunction);
+      } catch (err) {
+        console.error(err); // eslint-disable-line no-console
+      }
+    }, this.refreshRateInSeconds * 1000);
+
+    this.setIntervalIds.push(setIntervalId);
+  }
+
+  async pollSummaryData(callbackSetterFunction) {
+    // Populate initial data before we start polling
+    const urls = [ `/status_pages/${this.subDomain}/status` ];
+
+    await this._fetchAndPopulateData(urls, callbackSetterFunction);
+    this._pollData(urls, callbackSetterFunction);
+  }
+
+  async pollCurrentIncidents(callbackSetterFunction, callbackBeforePolling) {
+    const urls = [
+      `/status_pages/${this.subDomain}/status`,
+      `/status_pages/${this.subDomain}/incidents`
+    ];
+
+    await this._fetchAndPopulateData(urls, callbackSetterFunction);
+    this._pollData(urls, callbackSetterFunction, callbackBeforePolling);
+  }
+}


### PR DESCRIPTION
I added support for the provider [Statuspal](https://statuspal.io). Below are a few explanations for some of the changes I made because of how the Statuspal API works.

- I added a new field called `subDomain` in order for adding the provider to make a bit more sense. The provider gives each status page a Statuspal subdomain along with options to use a custom domain. The page just serves templated HTML so using the Statuspal API is a much simpler approach for getting the required data. When using the API you refer to the status page's subdomain.

- Currently, there is no support for incident updates. In order to get the updates for an incident, a separate API call is needed for each incident. While not necessarily an issue, the API runs into issues with CORS. So I'm using [cors-anywhere](https://github.com/Rob--W/cors-anywhere) as a temporary solution. The reason for limiting requests is because cors-anywhere has a limit of 200 requests per hour. Depending on how many incidents there are you can easily get rate limited.