### PR TITLE
Fix typo

### DIFF
--- a/nerdlets/status-page-dashboard/main-page.js
+++ b/nerdlets/status-page-dashboard/main-page.js
@@ -388,7 +388,7 @@ export default class StatusPagesDashboard extends React.PureComponent {
         updatedFormInputs.subDomain = { ...emptyInputState };
       } else {
         delete updatedFormInputs.nrqlQuery;
-        delete updatedFormInputs.worloadGuid;
+        delete updatedFormInputs.workloadGuid;
         updatedFormInputs.hostName = { ...emptyInputState };
       }
     }
@@ -753,7 +753,7 @@ export default class StatusPagesDashboard extends React.PureComponent {
             Cancel
           </Button>
           <Button type={Button.TYPE.PRIMARY} onClick={this.handleAddNewService}>
-            Add new serivce
+            Add new service
           </Button>
         </Modal>
       </div>


### PR DESCRIPTION
The `add service` button wasn't working for status page providers. Turned out to be a 1 letter typo (also fixed another in the button text)