### PR TITLE
Fix polling interval

### DIFF
--- a/utilities/nrql-helper.js
+++ b/utilities/nrql-helper.js
@@ -20,7 +20,7 @@ export default class NRQLHelper {
         accountId: this.accountId,
         query: this.query,
         formatType: NrqlQuery.FORMAT_TYPE.RAW,
-        pollInterval: this.refreshRateInSeconds
+        pollInterval: this.refreshRateInSeconds * 1000
       });
 
       if (networkResponse.data.metadata.messages[0]) {

--- a/utilities/workload-helper.js
+++ b/utilities/workload-helper.js
@@ -21,7 +21,7 @@ export default class WorkloadHelper {
         accountId: this.accountId,
         query: this.query,
         formatType: NrqlQuery.FORMAT_TYPE.RAW,
-        pollInterval: this.refreshRateInSeconds
+        pollInterval: this.refreshRateInSeconds * 1000
       });
 
       if (networkResponse.data.metadata.messages[0]) {


### PR DESCRIPTION
The `pollInterval` argument for `NrqlQuery.query` is milliseconds: https://developer.newrelic.com/components/nrql-query
